### PR TITLE
Devv

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Collates Fusion candidates and associated metadata from STAR-Fusion, FusionInspe
 - `-ifusioninspector_files` : An array of DNAnexus file IDs of FusionInspector's output files
 - `-imultiqc_files`: An array of DNAnexus file IDs of MultiQC output metrics file
 - `-iSF_previous_runs_data` : The DNAnexus file ID of a static file containing historical STAR-Fusion data
+- `ireference_sources` : The DNAnexus file ID of a static file containing aggregated data source from COSMIC, FusionDGB2 and ChimerDB
+- `iprevious_positives`: The DNAnexus file ID of a static file containing previously reported fusions
 
 ## How does this app work?
 - Parses all inputs and format data according to structure of source data

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Collates Fusion candidates and associated metadata from STAR-Fusion, FusionInspe
 ## What inputs are required for this app to run?
 - `-istarfusion_files` : An array of DNAnexus file IDs of STAR-Fusion's prediction files
 - `-ifusioninspector_files` : An array of DNAnexus file IDs of FusionInspector's output files
-- `-ifastqc_data`: The DNAnexus file ID of FASTQC metrics file
+- `-imultiqc_files`: An array of DNAnexus file IDs of MultiQC output metrics file
 - `-iSF_previous_runs_data` : The DNAnexus file ID of a static file containing historical STAR-Fusion data
 
 ## How does this app work?

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Collates Fusion candidates and associated metadata from STAR-Fusion, FusionInspe
 - `-iSF_previous_runs_data` : The DNAnexus file ID of a static file containing historical STAR-Fusion data
 - `ireference_sources` : The DNAnexus file ID of a static file containing aggregated data source from COSMIC, FusionDGB2 and ChimerDB
 - `iprevious_positives`: The DNAnexus file ID of a static file containing previously reported fusions
+
 [!NOTE]
+
 Currently, the `eggd_fusioninspector/1.0.0` app  produces three separate outputs: scientists, testdir_cosmic and rnaopa. The input field `fusioninspector_files` corresponds to the scientists output, while `fi_testdir_cosmic_files` and `fi_rna_opa_files` correspond to the latter two. However, in a future version of `eggd_fusioninspector`, these outputs will be merged into a single output, which will be used as the input for `fusioninspector_files`. As a result, the `fi_testdir_cosmic_files` and `fi_rna_opa_files` inputs are optional for now and will be deprecated once the update is released.
 
 ## How does this app work?

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Collates Fusion candidates and associated metadata from STAR-Fusion, FusionInspe
 ## What inputs are required for this app to run?
 - `-istarfusion_files` : An array of DNAnexus file IDs of STAR-Fusion's prediction files
 - `-ifusioninspector_files` : An array of DNAnexus file IDs of FusionInspector's output files
+- `-fi_testdir_cosmic_files` : (optional) An array of DNAnexus file IDs of FusionInspector's output (testdir_cosmic) files
+- `-ifi_rna_opa_files` : (optional) An array of DNAnexus file IDs of FusionInspector's output (rna_opa) files
 - `-imultiqc_files`: An array of DNAnexus file IDs of MultiQC output metrics file
 - `-iSF_previous_runs_data` : The DNAnexus file ID of a static file containing historical STAR-Fusion data
 - `ireference_sources` : The DNAnexus file ID of a static file containing aggregated data source from COSMIC, FusionDGB2 and ChimerDB
@@ -21,5 +23,5 @@ Collates Fusion candidates and associated metadata from STAR-Fusion, FusionInspe
 
 #### TODO
 - Add unit tests
-- optimise reading of large dx files
-- add more validations to parser module
+- Add scripts to generate static inputs
+- Add more validations to parser module

--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@ Collates Fusion candidates and associated metadata from STAR-Fusion, FusionInspe
 - `ireference_sources` : The DNAnexus file ID of a static file containing aggregated data source from COSMIC, FusionDGB2 and ChimerDB
 - `iprevious_positives`: The DNAnexus file ID of a static file containing previously reported fusions
 
-[!NOTE]
-
-Currently, the `eggd_fusioninspector/1.0.0` app  produces three separate outputs: scientists, testdir_cosmic and rnaopa. The input field `fusioninspector_files` corresponds to the scientists output, while `fi_testdir_cosmic_files` and `fi_rna_opa_files` correspond to the latter two. However, in a future version of `eggd_fusioninspector`, these outputs will be merged into a single output, which will be used as the input for `fusioninspector_files`. As a result, the `fi_testdir_cosmic_files` and `fi_rna_opa_files` inputs are optional for now and will be deprecated once the update is released.
+> [!NOTE]
+> Currently, the `eggd_fusioninspector/1.0.0` app  produces three separate outputs: scientists, testdir_cosmic and rnaopa. The input field `fusioninspector_files` corresponds to the scientists output, while `fi_testdir_cosmic_files` and `fi_rna_opa_files` correspond to the latter two. However, in a future version of `eggd_fusioninspector`, these outputs will be merged into a single output, which will be used as the input for `fusioninspector_files`. As a result, the `fi_testdir_cosmic_files` and `fi_rna_opa_files` inputs are optional for now and will be deprecated once the update is released.
 
 ## How does this app work?
 - Parses all inputs and format data according to structure of source data

--- a/README.md
+++ b/README.md
@@ -6,12 +6,14 @@ Collates Fusion candidates and associated metadata from STAR-Fusion, FusionInspe
 ## What inputs are required for this app to run?
 - `-istarfusion_files` : An array of DNAnexus file IDs of STAR-Fusion's prediction files
 - `-ifusioninspector_files` : An array of DNAnexus file IDs of FusionInspector's output files
-- `-fi_testdir_cosmic_files` : (optional) An array of DNAnexus file IDs of FusionInspector's output (testdir_cosmic) files
+- `-ifi_testdir_cosmic_files` : (optional) An array of DNAnexus file IDs of FusionInspector's output (testdir_cosmic) files
 - `-ifi_rna_opa_files` : (optional) An array of DNAnexus file IDs of FusionInspector's output (rna_opa) files
 - `-imultiqc_files`: An array of DNAnexus file IDs of MultiQC output metrics file
 - `-iSF_previous_runs_data` : The DNAnexus file ID of a static file containing historical STAR-Fusion data
 - `ireference_sources` : The DNAnexus file ID of a static file containing aggregated data source from COSMIC, FusionDGB2 and ChimerDB
 - `iprevious_positives`: The DNAnexus file ID of a static file containing previously reported fusions
+[!NOTE]
+Currently, the `eggd_fusioninspector/1.0.0` app  produces three separate outputs: scientists, testdir_cosmic and rnaopa. The input field `fusioninspector_files` corresponds to the scientists output, while `fi_testdir_cosmic_files` and `fi_rna_opa_files` correspond to the latter two. However, in a future version of `eggd_fusioninspector`, these outputs will be merged into a single output, which will be used as the input for `fusioninspector_files`. As a result, the `fi_testdir_cosmic_files` and `fi_rna_opa_files` inputs are optional for now and will be deprecated once the update is released.
 
 ## How does this app work?
 - Parses all inputs and format data according to structure of source data

--- a/dxapp.json
+++ b/dxapp.json
@@ -20,6 +20,20 @@
         "help": "FusionInspector output files for validation of fusions"
       },
       {
+        "name": "fi_testdir_cosmic_files",
+        "label": "fi_testdir_cosmic_files",
+        "class": "array:file",
+        "optional": true,
+        "help": "FusionInspector output (testdir_cosmic) files for validation of fusions"
+      },
+      {
+        "name": "fi_rna_opa_files",
+        "label": "fi_rna_opa_files",
+        "class": "array:file",
+        "optional": true,
+        "help": "FusionInspector output (rna_opa) files for validation of fusions"
+      },
+      {
         "name": "multiqc_files",
         "label": "multiqc_files",
         "class": "array:file",

--- a/dxapp.json
+++ b/dxapp.json
@@ -31,6 +31,18 @@
         "class": "file",
         "optional": false,
         "help": "File containing info of STAR-Fusion's predictons from previous runs"
+      },
+      {
+        "name": "reference_sources",
+        "class": "file",
+        "optional": false,
+        "help": "File containing aggregated data source from COSMIC, FusionDGB2 and ChimerDB"
+      },
+      {
+        "name": "previous_positives",
+        "class": "file",
+        "optional": false,
+        "help": "File containing previously reported fusions"
       }
     ],
     "outputSpec": [
@@ -56,8 +68,10 @@
       "release": "24.04",
       "version": "0"
     },
+    "openSource": true,
     "access": {
-      "project": "CONTRIBUTE"
+      "project": "CONTRIBUTE",
+      "allProjects": "CONTRIBUTE"
     },
     "regionalOptions": {
       "aws:eu-central-1": {

--- a/dxapp.json
+++ b/dxapp.json
@@ -20,11 +20,11 @@
         "help": "FusionInspector output files for validation of fusions"
       },
       {
-        "name": "fastqc_data",
-        "label": "fastqc_data",
-        "class": "file",
+        "name": "multiqc_files",
+        "label": "multiqc_files",
+        "class": "array:file",
         "optional": false,
-        "help": "FastQC output file containing quality metrics for the sequencing data"
+        "help": "MultiQC output files containing quality metrics for the sequencing data"
       },
       {
         "name": "SF_previous_runs_data",

--- a/resources/home/dnanexus/generate_fusion_workbook.py
+++ b/resources/home/dnanexus/generate_fusion_workbook.py
@@ -34,7 +34,7 @@ from utils.parser import (
     make_fastqc_pivot,
     make_sf_pivot,
     parse_sf_previous,
-    parse_prev_pos
+    parse_prev_pos,
 )
 from utils.summary_sheet import write_summary
 from utils.utils import (
@@ -51,7 +51,7 @@ def main(
     multiqc_files: List[dict],
     SF_previous_runs_data: dict,
     reference_sources: dict,
-    previous_positives: dict
+    previous_positives: dict,
 ):
     """Generates a fusion workbook with data from
     STAR-Fusion, FusionInspector, and FastQC
@@ -99,10 +99,10 @@ def main(
 
         # Writes empty EPIC sheet
         write_df_to_sheet(writer, pd.DataFrame(), **EPIC_SHEET_CONFIG)
-        
+
         # Writes RefSources sheet
         write_df_to_sheet(writer, df_ref_sources, **REF_SOURCES_SHEET_CONFIG)
-        
+
         # Writes PreviousPositives sheet
         write_df_to_sheet(writer, df_prev_pos, **PREV_POS_SHEET_CONFIG)
 

--- a/resources/home/dnanexus/generate_fusion_workbook.py
+++ b/resources/home/dnanexus/generate_fusion_workbook.py
@@ -37,6 +37,7 @@ from utils.summary_sheet import write_summary
 from utils.utils import (
     get_project_info,
     read_dxfile,
+    get_dxfile,
 )
 
 
@@ -44,7 +45,7 @@ from utils.utils import (
 def main(
     starfusion_files: List[dict],
     fusioninspector_files: List[dict],
-    fastqc_data: dict,
+    multiqc_files: List[dict],
     SF_previous_runs_data: dict,
 ):
     """Generates a fusion workbook with data from
@@ -56,8 +57,8 @@ def main(
         List of dictionaries containing DXLinks to STAR-Fusion output files
     fusioninspector_files : List[dict]
         List of dictionaries containing DXLinks to FusionInspector output files
-    fastqc_data : dict
-        Mapping of DXLink to FastQC data file
+    multiqc_files : List[dict]
+        List of dictionaries containing DXLinks to MultiQC output files
     SF_previous_runs_data : str
        Mapping of DXLink to STAR-Fusion previous runs data file
 
@@ -69,7 +70,8 @@ def main(
     # Initialize inputs into dxpy.DXDataObject instances
     starfusion_files = [dxpy.DXFile(item) for item in starfusion_files]
     fusioninspector_files = [dxpy.DXFile(item) for item in fusioninspector_files]
-    fastqc_data = dxpy.DXFile(fastqc_data)
+    multiqc_files = [dxpy.DXFile(item) for item in multiqc_files]
+    fastqc_data = get_dxfile(multiqc_files, "multiqc_fastqc.txt")
     sf_previous_data = dxpy.DXFile(SF_previous_runs_data)
 
     df_starfusion = parse_star_fusion(starfusion_files)

--- a/resources/home/dnanexus/generate_fusion_workbook.py
+++ b/resources/home/dnanexus/generate_fusion_workbook.py
@@ -52,6 +52,8 @@ def main(
     SF_previous_runs_data: dict,
     reference_sources: dict,
     previous_positives: dict,
+    fi_testdir_cosmic_files: List[dict] | None = None,
+    fi_rna_opa_files: List[dict] | None = None,
 ):
     """Generates a fusion workbook with data from
     STAR-Fusion, FusionInspector, and FastQC
@@ -70,6 +72,12 @@ def main(
        Mapping of DXLink to ReferenceSources file
     previous_positives : dict
        Mapping of DXLink to PreviousPositives file
+    fi_testdir_cosmic_files : List[dict]|None
+        List of dictionaries containing DXLinks to FusionInspector
+        (test_dir_cosmic) output files
+    fi_rna_opa_files : List[dict]|None
+        List of dictionaries containing DXLinks to FusionInspector
+        (rna_opa) output files
 
     Returns
     -------
@@ -84,6 +92,10 @@ def main(
     sf_previous_data = dxpy.DXFile(SF_previous_runs_data)
     ref_sources = dxpy.DXFile(reference_sources)
     previous_positives = dxpy.DXFile(previous_positives)
+    if fi_testdir_cosmic_files is not None:
+        fusioninspector_files += [dxpy.DXFile(item) for item in fi_testdir_cosmic_files]
+    if fi_rna_opa_files is not None:
+        fusioninspector_files += [dxpy.DXFile(item) for item in fi_rna_opa_files]
 
     df_starfusion = parse_star_fusion(starfusion_files)
     df_fusioninspector = parse_fusion_inspector(fusioninspector_files)

--- a/resources/home/dnanexus/utils/defaults.py
+++ b/resources/home/dnanexus/utils/defaults.py
@@ -138,5 +138,5 @@ SF_PIVOT_CONFIG = {
         "EPIC": "=VLOOKUP(B{row},'EPIC'!AJ:AK,2,0)",
         "DAYS COUNT": "=VLOOKUP(B{row},'EPIC'!AJ:AL,3,0)",
     },
-    "col_widths": {"D": 6, "E": 10, "F": 10, "J": 6, "K": 6, "L": 6},
+    "col_widths": {"D": 6, "E": 10, "F": 10, "J": 6, "K": 6, "L": 6, "M": 24, "N": 24},
 }

--- a/resources/home/dnanexus/utils/defaults.py
+++ b/resources/home/dnanexus/utils/defaults.py
@@ -52,6 +52,18 @@ EPIC_SHEET_CONFIG = {
     "extra_cols": None,
 }
 
+REF_SOURCES_SHEET_CONFIG = {
+    "sheet_name": "ReferenceSources",
+    "tab_color": "17171A",
+    "extra_cols": None,
+}
+
+PREV_POS_SHEET_CONFIG = {
+    "sheet_name": "PreviousPositives",
+    "tab_color": "17171A",
+    "extra_cols": None,
+}
+
 
 FASTQC_PIVOT_CONFIG = {
     "index": ["SPECIMEN"],
@@ -84,6 +96,8 @@ SF_PIVOT_CONFIG = {
         "#FusionName",
         "LeftBreakpoint",
         "RightBreakpoint",
+        "ReferenceSources",
+        "PreviousPositives",
     ],
     "aggfunc": {
         "#FusionName": "first",
@@ -94,6 +108,8 @@ SF_PIVOT_CONFIG = {
         "JunctionReadCount": "first",
         "LeftBreakpoint": "first",
         "RightBreakpoint": "first",
+        "ReferenceSources": "first",
+        "PreviousPositives": "first",
     },
     "sheet_name": "Summary",
     "tab_color": "CFBF30",

--- a/resources/home/dnanexus/utils/parser.py
+++ b/resources/home/dnanexus/utils/parser.py
@@ -195,8 +195,8 @@ def parse_fusion_inspector(dxfiles: List[DXDataObject]) -> pd.DataFrame:
     """
     df = _parse_fusion_files(dxfiles)
     df["file_name"] = (
-        df["file_name"].str.split("_").str[0] +
-        "_FusionInspector.fusions.abridged.merged.tsv"
+        df["file_name"].str.split("_").str[0]
+        + "_FusionInspector.fusions.abridged.merged.tsv"
     )
     df = (
         df.sort_values(by=["JunctionReadCount", "SpanningFragCount"])
@@ -308,8 +308,7 @@ def make_sf_pivot(
         df = df.merge(
             fi_df[["LEFTRIGHT", "PROT_FUSION_TYPE"]], on="LEFTRIGHT", how="left"
         ).rename(columns={"PROT_FUSION_TYPE": "FRAME"})
-        
-    
+
     # add prev positives
     prev_pos_agg = (
         prev_pos.groupby("Fusion")["Specimen ID"]
@@ -318,20 +317,20 @@ def make_sf_pivot(
         .rename(columns={"Fusion": "#FusionName", "Specimen ID": "PreviousPositives"})
     )
     df = df.merge(prev_pos_agg, on="#FusionName", how="left")
-    df["PreviousPositives"] = df["PreviousPositives"].fillna("NO")
-    
+    df["PreviousPositives"] = df["PreviousPositives"].fillna("")
+
     # add ref sources
     df = df.merge(
         ref_sources.rename(columns={"Fusion": "#FusionName"}),
         on="#FusionName",
-        how="left"
+        how="left",
     )
     df["ReferenceSources"] = df["ReferenceSources"].fillna("")
 
     # Create final pivot table
     df = df.sort_values(by=["FFPM"]).reset_index(drop=True)
     pivot_df = create_pivot_table(df, pivot_config)
-    
+
     pivot_df = pivot_df[
         [
             "LeftBreakpoint",

--- a/resources/home/dnanexus/utils/parser.py
+++ b/resources/home/dnanexus/utils/parser.py
@@ -193,9 +193,17 @@ def parse_fusion_inspector(dxfiles: List[DXDataObject]) -> pd.DataFrame:
         A concatenated DataFrame containing the combined data
         from all input files.
     """
-    # simply calls _parse_fusion_files for now
-    # can be easily extended if additional logic needed for tool
-    return _parse_fusion_files(dxfiles)
+    df = _parse_fusion_files(dxfiles)
+    df["file_name"] = (
+        df["file_name"].str.split("_").str[0] +
+        "_FusionInspector.fusions.abridged.merged.tsv"
+    )
+    df = (
+        df.sort_values(by=["JunctionReadCount", "SpanningFragCount"])
+        .drop_duplicates()
+        .reset_index(drop=True)
+    )
+    return df
 
 
 def parse_star_fusion(dxfiles: List[DXDataObject]) -> pd.DataFrame:

--- a/resources/home/dnanexus/utils/utils.py
+++ b/resources/home/dnanexus/utils/utils.py
@@ -138,3 +138,32 @@ def validate_config(config: dict, expected_keys: list):
     missing_keys = [key for key in expected_keys if key not in config]
     if missing_keys:
         raise ValueError(f"Missing required config key(s): {', '.join(missing_keys)}")
+ 
+
+def get_dxfile(files: list[dxpy.DXDataObject], target_name: str) -> dxpy.DXDataObject:
+    """Finds a DXDataObject in the given list that matches the specified filename.
+
+    Parameters
+    ----------
+    files : list[dxpy.DXDataObject]
+        List of DNAnexus data objects (e.g., DXFile instances)
+    target_name : str
+        The exact file name to search for (case-sensitive match).
+
+    Returns
+    -------
+    dxpy.DXDataObject
+        The first DXDataObject with a .name attribute matching `target_name`.
+
+    Raises
+    ------
+    ValueError
+        If no file with the specified name is found in the list.
+    """
+    
+    try:
+        return next(f for f in files if f.name == target_name)
+    except StopIteration:
+        raise ValueError(
+            f"{target_name} not found in input array"
+        )

--- a/resources/home/dnanexus/utils/utils.py
+++ b/resources/home/dnanexus/utils/utils.py
@@ -138,7 +138,7 @@ def validate_config(config: dict, expected_keys: list):
     missing_keys = [key for key in expected_keys if key not in config]
     if missing_keys:
         raise ValueError(f"Missing required config key(s): {', '.join(missing_keys)}")
- 
+
 
 def get_dxfile(files: list[dxpy.DXDataObject], target_name: str) -> dxpy.DXDataObject:
     """Finds a DXDataObject in the given list that matches the specified filename.
@@ -160,10 +160,8 @@ def get_dxfile(files: list[dxpy.DXDataObject], target_name: str) -> dxpy.DXDataO
     ValueError
         If no file with the specified name is found in the list.
     """
-    
+
     try:
         return next(f for f in files if f.name == target_name)
     except StopIteration:
-        raise ValueError(
-            f"{target_name} not found in input array"
-        )
+        raise ValueError(f"{target_name} not found in input array")


### PR DESCRIPTION
- Add input of multiqc array and get fastqc data
- Take inputs from three instances of fusion inspector
-  Add static inputs Reference sources and previous positives
Job:https://platform.dnanexus.com/panx/projects/Gz4kFpQ48F3YXzV94xXQ220Q/monitor/job/J09gYj048F3pY9Zqb7XPbf1K

@jethror1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_fusion_workbook/4)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for new input files: FusionInspector testdir_cosmic and rna_opa outputs, MultiQC metrics, aggregated reference sources, and previously reported fusions.
  - STAR-Fusion pivot tables now incorporate historical fusion positivity and reference source metadata.
- **Documentation**
  - Updated README to reflect new and modified input parameters, removed outdated references, and revised the TODO section.
- **Bug Fixes**
  - Enhanced FusionInspector file parsing with standardised file name formatting and improved data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->