### PR TITLE
Di 3139 generate fusion workbook v1.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # eggd_generate_fusion_workbook (DNAnexus Platform App)
 
 ## What does this app do?
-Collates Fusion candidates and associated metadata from STAR-Fusion, FusionInspector and FastQC per run, then formats and generate a fusion workbook with collated data
+Collates fusion candidates and associated metadata from STAR-Fusion, Arriba and FastQC per run, then formats and generates a fusion workbook with collated data
 
 ## What inputs are required for this app to run?
 - `-istarfusion_files` : An array of DNAnexus file IDs of STAR-Fusion's prediction files
@@ -9,7 +9,7 @@ Collates Fusion candidates and associated metadata from STAR-Fusion, FusionInspe
 - `-iarriba_files`: An array of DNAnexus file IDs of Arriba output fusion files from STAR aligned BAMs
 - `-imultiqc_files`: An array of DNAnexus file IDs of MultiQC output metrics file
 - `-iSF_previous_runs_data` : The DNAnexus file ID of a static file containing historical STAR-Fusion data
-- `ireference_sources` : The DNAnexus file ID of a static file containing aggregated data source from COSMIC, FusionDGB2 and ChimerDB
+- `-ireference_sources` : The DNAnexus file ID of a static file containing aggregated data source from COSMIC, FusionDGB2 and ChimerDB
 - `iprevious_positives`: The DNAnexus file ID of a static file containing previously reported fusions
 
 ## How does this app work?
@@ -30,7 +30,7 @@ python3 scripts/generate_inputs.py -p <project_id>
 The above will write the file `input.json` which can then be passed to the `dx run` command below.
 
 ```
-dx run eggd_eggd_generate_fusion_workbook/1.1.0 \
+dx run eggd_eggd_generate_fusion_workbook/1.2.0 \
 -f input.json \
 --destination {}
 ```

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Collates Fusion candidates and associated metadata from STAR-Fusion, FusionInspe
 
 ## What inputs are required for this app to run?
 - `-istarfusion_files` : An array of DNAnexus file IDs of STAR-Fusion's prediction files
-- `-ifusioninspector_files` : An array of DNAnexus file IDs of FusionInspector's output files
+- `-ifusioninspector_files` *(optional)*: An array of DNAnexus file IDs of FusionInspector's output files. If provided, the FusionInspector sheet will be included in the workbook
 - `-iarriba_files`: An array of DNAnexus file IDs of Arriba output fusion files from STAR aligned BAMs
 - `-imultiqc_files`: An array of DNAnexus file IDs of MultiQC output metrics file
 - `-iSF_previous_runs_data` : The DNAnexus file ID of a static file containing historical STAR-Fusion data

--- a/dxapp.json
+++ b/dxapp.json
@@ -3,7 +3,7 @@
     "title": "eggd_generate_fusion_workbook",
     "summary": "App for fusion workbook",
     "dxapi": "1.1.0",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "inputSpec": [
       {
         "name": "starfusion_files",

--- a/dxapp.json
+++ b/dxapp.json
@@ -16,7 +16,7 @@
         "name": "fusioninspector_files",
         "label": "fusioninspector_files",
         "class": "array:file",
-        "optional": false,
+        "optional": true,
         "help": "FusionInspector output files for validation of fusions"
       },
       {

--- a/resources/home/dnanexus/generate_fusion_workbook.py
+++ b/resources/home/dnanexus/generate_fusion_workbook.py
@@ -146,6 +146,7 @@ def main(
             df_sf_previous,
             fastqc_pivot,
             df_fusioninspector,
+            df_arriba,
             df_prev_pos,
             df_ref_sources,
             SF_PIVOT_CONFIG,

--- a/resources/home/dnanexus/generate_fusion_workbook.py
+++ b/resources/home/dnanexus/generate_fusion_workbook.py
@@ -132,8 +132,9 @@ def main(
             extra_cols=FASTQC_PIVOT_CONFIG["extra_cols"],
             start_col=FASTQC_PIVOT_CONFIG["start_col"],
         )
-        # Add Fusion Inspector data
-        write_df_to_sheet(writer, df_fusioninspector, **FI_SHEET_CONFIG)
+        # Add Fusion Inspector data (only if data was provided)
+        if not df_fusioninspector.empty:
+            write_df_to_sheet(writer, df_fusioninspector, **FI_SHEET_CONFIG)
 
         # Add Arriba data
         write_df_to_sheet(writer, df_arriba, **ARRIBA_SHEET_CONFIG)

--- a/resources/home/dnanexus/generate_fusion_workbook.py
+++ b/resources/home/dnanexus/generate_fusion_workbook.py
@@ -4,7 +4,7 @@
 import os
 from glob import glob
 import subprocess
-from typing import List
+from typing import List, Optional
 
 if os.path.exists("/home/dnanexus"):
     # running in DNAnexus
@@ -49,12 +49,12 @@ from utils.utils import (
 @dxpy.entry_point("main")
 def main(
     starfusion_files: List[dict],
-    fusioninspector_files: List[dict],
     arriba_files: List[dict],
     multiqc_files: List[dict],
     SF_previous_runs_data: dict,
     reference_sources: dict,
     previous_positives: dict,
+    fusioninspector_files: Optional[List[dict]] = None,
 ):
     """Generates a fusion workbook with data from
     STAR-Fusion, FusionInspector, Arriba, and FastQC
@@ -63,8 +63,6 @@ def main(
     ----------
     starfusion_files : List[dict]
         List of dictionaries containing DXLinks to STAR-Fusion output files
-    fusioninspector_files : List[dict]
-        List of dictionaries containing DXLinks to FusionInspector output files
     arriba_files : List[dict]
         List of dictionaries containing DXLinks to Arriba output files
     multiqc_files : List[dict]
@@ -75,6 +73,8 @@ def main(
        Mapping of DXLink to ReferenceSources file
     previous_positives : dict
        Mapping of DXLink to PreviousPositives file
+    fusioninspector_files : Optional[List[dict]]
+        List of dictionaries containing DXLinks to FusionInspector output files
 
     Returns
     -------
@@ -83,7 +83,6 @@ def main(
     """
     # Initialize inputs into dxpy.DXDataObject instances
     starfusion_files = [dxpy.DXFile(item) for item in starfusion_files]
-    fusioninspector_files = [dxpy.DXFile(item) for item in fusioninspector_files]
     arriba_files = [dxpy.DXFile(item) for item in arriba_files]
     multiqc_files = [dxpy.DXFile(item) for item in multiqc_files]
     fastqc_data = get_dxfile(multiqc_files, "multiqc_fastqc.txt")
@@ -91,8 +90,14 @@ def main(
     ref_sources = dxpy.DXFile(reference_sources)
     previous_positives = dxpy.DXFile(previous_positives)
 
+    #Parse FusionInspector files if provided (optional input)
+    if fusioninspector_files:
+        fusioninspector_files = [dxpy.DXFile(item) for item in fusioninspector_files]
+        df_fusioninspector = parse_fusion_inspector(fusioninspector_files)
+    else:
+        df_fusioninspector = pd.DataFrame()
+
     df_starfusion = parse_star_fusion(starfusion_files)
-    df_fusioninspector = parse_fusion_inspector(fusioninspector_files)
     df_arriba = parse_arriba(arriba_files)
     df_fastqc = parse_fastqc(fastqc_data)
     df_sf_previous = parse_sf_previous(sf_previous_data)

--- a/resources/home/dnanexus/generate_fusion_workbook.py
+++ b/resources/home/dnanexus/generate_fusion_workbook.py
@@ -145,7 +145,6 @@ def main(
             df_starfusion,
             df_sf_previous,
             fastqc_pivot,
-            df_fusioninspector,
             df_arriba,
             df_prev_pos,
             df_ref_sources,

--- a/resources/home/dnanexus/tests/test_parser.py
+++ b/resources/home/dnanexus/tests/test_parser.py
@@ -159,8 +159,8 @@ class TestMakeSfPivot:
         cls.sf_df = pd.DataFrame(
             {
                 "#FusionName": ["A--B"],
-                "LeftBreakpoint": ["chr1:123"],
-                "RightBreakpoint": ["chr2:456"],
+                "LeftBreakpoint": ["chr1:123:+"],
+                "RightBreakpoint": ["chr2:456:+"],
                 "file_name": ["123-2XX-ABC"],
                 "JunctionReadCount": [100],
                 "SpanningFragCount": [200],
@@ -182,18 +182,12 @@ class TestMakeSfPivot:
             }
         )
 
-        cls.fi_df = pd.DataFrame(
-            {
-                "LeftBreakpoint": ["chr1:123"],
-                "RightBreakpoint": ["chr2:456"],
-                "PROT_FUSION_TYPE": ["in-frame"],
-            }
-        )
-
         cls.arriba_df = pd.DataFrame(
             {
                 "breakpoint1": ["chr1:123"],
+                "strand1(gene/fusion)": ["+/+"],
                 "breakpoint2": ["chr2:456"],
+                "strand2(gene/fusion)": ["+/+"],
                 "reading_frame": ["in-frame"],
             }
         )
@@ -233,7 +227,6 @@ class TestMakeSfPivot:
             cls.sf_df,
             cls.sf_runs_df,
             cls.fastqc_pivot_df,
-            cls.fi_df,
             cls.arriba_df,
             cls.prev_pos,
             cls.ref_sources,

--- a/resources/home/dnanexus/tests/test_parser.py
+++ b/resources/home/dnanexus/tests/test_parser.py
@@ -190,6 +190,14 @@ class TestMakeSfPivot:
             }
         )
 
+        cls.arriba_df = pd.DataFrame(
+            {
+                "breakpoint1": ["chr1:123"],
+                "breakpoint2": ["chr2:456"],
+                "reading_frame": ["in-frame"],
+            }
+        )
+
         cls.prev_pos = pd.DataFrame(
             {
                 "Specimen Identifier": ["SP1"],
@@ -226,6 +234,7 @@ class TestMakeSfPivot:
             cls.sf_runs_df,
             cls.fastqc_pivot_df,
             cls.fi_df,
+            cls.arriba_df,
             cls.prev_pos,
             cls.ref_sources,
             cls.pivot_config,

--- a/resources/home/dnanexus/tests/test_parser.py
+++ b/resources/home/dnanexus/tests/test_parser.py
@@ -257,3 +257,65 @@ class TestMakeSfPivot:
         assert row["#FusionName"] == "A--B"
         assert row["FRAME"] == "in-frame"
         assert row["ReferenceSources"] == "ChimerKDB"
+
+
+class TestMakeSfPivotNoArriba:
+    """Unit tests for make_sf_pivot when arriba_df is empty (no FRAME column)."""
+
+    @classmethod
+    def setup_class(cls):
+        cls.sf_df = pd.DataFrame(
+            {
+                "#FusionName": ["A--B"],
+                "LeftBreakpoint": ["chr1:123:+"],
+                "RightBreakpoint": ["chr2:456:+"],
+                "file_name": ["123-2XX-ABC"],
+                "JunctionReadCount": [100],
+                "SpanningFragCount": [200],
+                "FFPM": [10.5],
+            }
+        )
+        cls.sf_runs_df = pd.DataFrame({"#FusionName": ["A--B"], "Count_predicted": [5]})
+        cls.fastqc_pivot_df = pd.DataFrame(
+            {"SPECIMEN": ["2XX"], "Unique Reads": [1_000_000]}
+        )
+        cls.arriba_df = pd.DataFrame()
+        cls.prev_pos = pd.DataFrame(
+            {"Specimen Identifier": ["SP1"], "#FusionName": [["A--B"]]}
+        )
+        cls.ref_sources = pd.DataFrame(
+            {"Fusion": ["A--B"], "ReferenceSources": ["ChimerKDB"]}
+        )
+        cls.pivot_config = {
+            "index": ["SPECIMEN", "LEFTRIGHT"],
+            "columns": None,
+            "values": [
+                "LeftBreakpoint",
+                "#FusionName",
+                "RightBreakpoint",
+                "JunctionReadCount",
+                "SpanningFragCount",
+                "Count_predicted",
+                "ReferenceSources",
+                "PreviousPositives",
+                "FFPM",
+            ],
+        }
+        cls.result = parser.make_sf_pivot(
+            cls.sf_df,
+            cls.sf_runs_df,
+            cls.fastqc_pivot_df,
+            cls.arriba_df,
+            cls.prev_pos,
+            cls.ref_sources,
+            cls.pivot_config,
+        )
+
+    def test_pivot_does_not_raise(self):
+        assert not self.result.empty
+
+    def test_frame_column_absent(self):
+        assert "FRAME" not in self.result.columns
+
+    def test_ffpm_column_present(self):
+        assert "FFPM" in self.result.columns

--- a/resources/home/dnanexus/utils/defaults.py
+++ b/resources/home/dnanexus/utils/defaults.py
@@ -25,7 +25,6 @@ SF_SHEET_CONFIG = {
         "Duplicate Reads(M)": "=VLOOKUP(A{row},'FastQC_Pivot'!A:B,2,0)",
         "ID": '=CONCATENATE(A{row},"_",L{row})',
         "LEFTRIGHT": '=CONCATENATE(S{row},"_",U{row})',
-        "FRAME": "=VLOOKUP(I{row},'Fusion_Inspector'!C:AM,32,0)",
     },
     "col_widths": {"K": 10},
 }

--- a/resources/home/dnanexus/utils/parser.py
+++ b/resources/home/dnanexus/utils/parser.py
@@ -309,6 +309,7 @@ def make_sf_pivot(
     sf_runs_df: pd.DataFrame,
     fastqc_pivot_df: pd.DataFrame,
     fi_df: pd.DataFrame,
+    arriba_df: pd.DataFrame,
     prev_pos: pd.DataFrame,
     ref_sources: pd.DataFrame,
     pivot_config: dict,
@@ -325,6 +326,8 @@ def make_sf_pivot(
         FastQC summary data
     fi_df : pd.DataFrame
         Current Fusion Inspector data
+    arriba_df : pd.DataFrame
+        Current Arriba data
     prev_pos : pd.DataFrame
         Previously reported Fusions
     ref_sources : pd.DataFrame
@@ -365,14 +368,18 @@ def make_sf_pivot(
     if not fastqc_pivot_df.empty:
         df = df.merge(fastqc_pivot_df, on="SPECIMEN", how="left")
 
-    # Merge Fusion Inspector data
-    if not fi_df.empty:
-        fi_df["LEFTRIGHT"] = fi_df["LeftBreakpoint"] + "_" + fi_df["RightBreakpoint"]
+    # Merge Arriba data
+    if not arriba_df.empty:
+        arriba_df["LEFTRIGHT"] = arriba_df["breakpoint1"] + "_" + arriba_df["breakpoint2"]
+        df["LEFTRIGHT"] = (
+            df["LeftBreakpoint"].str.replace(r":[+-]$", "", regex=True)
+            + "_"
+            + df["RightBreakpoint"].str.replace(r":[+-]$", "", regex=True)
+        )
         df = df.merge(
-            fi_df[["LEFTRIGHT", "PROT_FUSION_TYPE"]], on="LEFTRIGHT", how="left"
-        ).rename(columns={"PROT_FUSION_TYPE": "FRAME"})
-    else:
-        df["FRAME"] = pd.NA
+            arriba_df[["LEFTRIGHT", "reading_frame"]], on="LEFTRIGHT", how="left"
+        ).rename(columns={"reading_frame": "FRAME"})
+
 
     # add prev positives
     prev_pos = (

--- a/resources/home/dnanexus/utils/parser.py
+++ b/resources/home/dnanexus/utils/parser.py
@@ -308,7 +308,6 @@ def make_sf_pivot(
     sf_df: pd.DataFrame,
     sf_runs_df: pd.DataFrame,
     fastqc_pivot_df: pd.DataFrame,
-    fi_df: pd.DataFrame,
     arriba_df: pd.DataFrame,
     prev_pos: pd.DataFrame,
     ref_sources: pd.DataFrame,
@@ -324,8 +323,6 @@ def make_sf_pivot(
         Historical STAR-Fusion data
     fastqc_pivot_df : pd.DataFrame
         FastQC summary data
-    fi_df : pd.DataFrame
-        Current Fusion Inspector data
     arriba_df : pd.DataFrame
         Current Arriba data
     prev_pos : pd.DataFrame
@@ -370,11 +367,14 @@ def make_sf_pivot(
 
     # Merge Arriba data
     if not arriba_df.empty:
-        arriba_df["LEFTRIGHT"] = arriba_df["breakpoint1"] + "_" + arriba_df["breakpoint2"]
-        df["LEFTRIGHT"] = (
-            df["LeftBreakpoint"].str.replace(r":[+-]$", "", regex=True)
+        arriba_df["LEFTRIGHT"] = (
+            arriba_df["breakpoint1"]
+            + ":"
+            + arriba_df["strand1(gene/fusion)"].str.split("/").str[1]
             + "_"
-            + df["RightBreakpoint"].str.replace(r":[+-]$", "", regex=True)
+            + arriba_df["breakpoint2"]
+            + ":"
+            + arriba_df["strand2(gene/fusion)"].str.split("/").str[1]
         )
         df = df.merge(
             arriba_df[["LEFTRIGHT", "reading_frame"]], on="LEFTRIGHT", how="left"

--- a/resources/home/dnanexus/utils/parser.py
+++ b/resources/home/dnanexus/utils/parser.py
@@ -403,8 +403,7 @@ def make_sf_pivot(
         .sort_values(by=["SPECIMEN", "LEFTRIGHT"], na_position="first")
     )
 
-    pivot_df = pivot_df[
-        [
+    cols = [
             "LeftBreakpoint",
             "#FusionName",
             "RightBreakpoint",
@@ -416,6 +415,9 @@ def make_sf_pivot(
             "FRAME",
             "FFPM",
         ]
-    ]
+    if not fi_df.empty:
+        cols.insert(-1, "FRAME")
+
+    pivot_df = pivot_df[cols]
 
     return pivot_df

--- a/resources/home/dnanexus/utils/parser.py
+++ b/resources/home/dnanexus/utils/parser.py
@@ -371,6 +371,8 @@ def make_sf_pivot(
         df = df.merge(
             fi_df[["LEFTRIGHT", "PROT_FUSION_TYPE"]], on="LEFTRIGHT", how="left"
         ).rename(columns={"PROT_FUSION_TYPE": "FRAME"})
+    else:
+        df["FRAME"] = pd.NA
 
     # add prev positives
     prev_pos = (
@@ -412,10 +414,9 @@ def make_sf_pivot(
             "Count_predicted",
             "ReferenceSources",
             "PreviousPositives",
+            "FRAME",
             "FFPM",
         ]
-    if not fi_df.empty:
-        cols.insert(-1, "FRAME")
 
     pivot_df = pivot_df[cols]
 

--- a/resources/home/dnanexus/utils/parser.py
+++ b/resources/home/dnanexus/utils/parser.py
@@ -413,17 +413,18 @@ def make_sf_pivot(
     )
 
     cols = [
-            "LeftBreakpoint",
-            "#FusionName",
-            "RightBreakpoint",
-            "JunctionReadCount",
-            "SpanningFragCount",
-            "Count_predicted",
-            "ReferenceSources",
-            "PreviousPositives",
-            "FRAME",
-            "FFPM",
-        ]
+        "LeftBreakpoint",
+        "#FusionName",
+        "RightBreakpoint",
+        "JunctionReadCount",
+        "SpanningFragCount",
+        "Count_predicted",
+        "ReferenceSources",
+        "PreviousPositives",
+    ]
+    if "FRAME" in pivot_df.columns:
+        cols.append("FRAME")
+    cols.append("FFPM")
 
     pivot_df = pivot_df[cols]
 

--- a/resources/home/dnanexus/utils/parser.py
+++ b/resources/home/dnanexus/utils/parser.py
@@ -412,7 +412,6 @@ def make_sf_pivot(
             "Count_predicted",
             "ReferenceSources",
             "PreviousPositives",
-            "FRAME",
             "FFPM",
         ]
     if not fi_df.empty:


### PR DESCRIPTION
Made fusioninspector_files an optional input in dxapp.json
Updated generate_fusion_workbook.py to accept fusioninspector_files as an optional parameter
Added a conditional logic to only parse FusionInspector files if they are provided
Skip writing FusionInspector sheet to the workbook if no data is provided

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_generate_fusion_workbook/19)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - FusionInspector input is now optional when generating workbooks.
  - FusionInspector results are included only when data is available.
  - STAR-Fusion pivot results now incorporate Arriba data and reading-frame information where applicable.

- **Bug Fixes**
  - Corrected reference-source option naming.
  - Improved pivot output when Arriba data is unavailable.

- **Documentation**
  - Updated app descriptions and command-line examples for version 1.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->